### PR TITLE
Cygwin Fixes

### DIFF
--- a/langtool.el
+++ b/langtool.el
@@ -507,6 +507,7 @@ String that separated by comma or list of string.
           (finish (process-get proc 'langtool-region-finish))
           n-tuple)
       (goto-char min)
+      (delete-trailing-whitespace)
       (while (re-search-forward langtool-output-regexp nil t)
         (let* ((line (string-to-number (match-string 1)))
                (column (1- (string-to-number (match-string 2))))

--- a/langtool.el
+++ b/langtool.el
@@ -141,13 +141,13 @@
 (defconst langtool-output-regexp
   (eval-when-compile
     (concat
-     "^[0-9]+\\.) Line \\([0-9]+\\), column \\([0-9]+\\), Rule ID: \\(.*\\)\n"
-     "Message: \\(.*\\)\n"
-     "\\(?:Suggestion: \\(.*\\)\n\\)?"
+     "^[0-9]+\\.) Line \\([0-9]+\\), column \\([0-9]+\\), Rule ID: \\(.*\\)\r?\n"
+     "Message: \\(.*\\)\r?\n"
+     "\\(?:Suggestion: \\(.*\\)\r?\n\\)?"
      ;; As long as i can read
      ;; src/dev/de/danielnaber/languagetool/dev/wikipedia/OutputDumpHandler.java
-     "\\(\\(?:.*\\)\n\\(?:[ ^]+\\)\\)\n"
-     "\n?"                              ; last result have no new-line
+     "\\(\\(?:.*\\)\r?\n\\(?:[ ^]+\\)\\)\r?\n"
+     "\r?\n?"                              ; last result have no new-line
      )))
 
 ;;

--- a/langtool.el
+++ b/langtool.el
@@ -572,6 +572,20 @@ String that separated by comma or list of string.
                              "\\)")))))
       regexp)))
 
+
+(defun langtool--file-name (path)
+  "Correct the file name depending on the underlying platform.
+
+PATH: The file-name path to be corrected.
+
+Currently corrects the file-name-path when running under Cygwin."
+  (if (eq system-type 'cygwin)
+      (replace-regexp-in-string "[ \n\r]*\\'" ""
+                                (shell-command-to-string
+                                 (concat "cygpath --windows " path)))
+    path))
+
+
 (defun langtool--invoke-process (file begin finish &optional lang)
   (when (listp mode-line-process)
     (add-to-list 'mode-line-process '(t langtool-mode-line-message)))
@@ -588,11 +602,12 @@ String that separated by comma or list of string.
                                  "org.languagetool.commandline.Main")
                            args))
       (setq args (append
-                  (list "-jar" (expand-file-name langtool-language-tool-jar))
+                  (list "-jar" (langtool--file-name
+                                (expand-file-name langtool-language-tool-jar)))
                   args)))
     (when langtool-mother-tongue
       (setq args (append args (list "-m" langtool-mother-tongue))))
-    (setq args (append args (list file)))
+    (setq args (append args (list (langtool--file-name file))))
     (langtool--debug "Command" "%s: %s" command args)
     (let* ((buffer (langtool--process-create-buffer))
            (proc (apply 'start-process "LanguageTool" buffer command args)))


### PR DESCRIPTION
Various fixes when running under Cygwin:

Java requires one path while Cygwin another. Fixed with a small wrapper function that corrects it for Cygwin.

The output to the temporary buffers contain carriage returns making the `langtool-output-regexp´ fail to match anything. Changing the regexp for newline to "\r?\n" fixes this.

For `langtool-correct-buffer` you will be prompted to insert strings with carriage returns, so performing `delete-trailing-whitespace` when filtering is still adviced.

This should close #17.