### PR TITLE
Filter out some useless things before checking

### DIFF
--- a/langtool.el
+++ b/langtool.el
@@ -1158,7 +1158,9 @@ BASE-MAJOR-MODE is the major mode to use for FILE."
     (when (and (derived-mode-p 'latex-mode) langtool-cleanup-latex)
       (langtool--clear-regex "\\$[^$]+\\$")
       (langtool--clear-regex "\\\\[[^]]+\\\\]")
-      (langtool--clear-regex "\\\\[^\\\\{\\[ ]*\\(\\[[^]]*\\]\\)*\\({[^}]*}\\)*\\(\\[[^]]*\\]\\)*"))
+      (langtool--clear-regex "\\\\[^\\\\{\\[ ]*\\(\\[[^]]*\\]\\)*\\({[^}]*}\\)*\\(\\[[^]]*\\]\\)*")
+      (langtool--clear-regex "~"))
+
     ;; Remove user regex if present
     (if (not (= (length langtool-cleanup-regex) 0))
         (langtool--clear-regex langtool-cleanup-regex))

--- a/langtool.el
+++ b/langtool.el
@@ -1110,11 +1110,19 @@ Goto previous error."
 ;;;###autoload
 (defalias 'langtool-check 'langtool-check-buffer)
 
+(defcustom langtool-cleanup-latex
+  nil
+  "If t, remove comments, commands and maths from latex buffer before sending
+them to langtool."
+  :type 'boolean
+  :group 'langtool)
+
 (defcustom langtool-cleanup-regex
   ""
   "Regular expression used to clean buffers before sending them to langtool.
 You can use this to remove part of the buffer you don't want to be spell checked."
-  :type 'regexp)
+  :type 'regexp
+  :group 'langtool)
 
 (defun langtool--clear-regex (regex)
   "Replace the strings matched by REGEX by spaces in the current buffer."
@@ -1147,7 +1155,7 @@ BASE-MAJOR-MODE is the major mode to use for FILE."
             (insert " "))
         (forward-char)))
     ;; Latex specific cleaning
-    (when (derived-mode-p 'latex-mode)
+    (when (and (derived-mode-p 'latex-mode) langtool-cleanup-latex)
       (langtool--clear-regex "\\$[^$]+\\$")
       (langtool--clear-regex "\\\\[[^]]+\\\\]")
       (langtool--clear-regex "\\\\[^\\\\{\\[ ]*\\(\\[[^]]*\\]\\)*\\({[^}]*}\\)*\\(\\[[^]]*\\]\\)*"))


### PR DESCRIPTION
Related to issue #4.
This use regular expression to replace comments, commands and maths environments with spaces in latex buffers before sending it to langtool.
This is not perfect, as regular expression are not really good at understanding nested braces, but it makes `emacs-langtool` definitely more pleasant to use in latex.
It is quite greedy, and removes everything between braces (figure caption too for example), that's why it is deactivated by default (`langtool-cleanup-latex` option to `nil`).

`langtool-clean-regex` allow also to specify arbitrary regex that will be cleanup (for other modes than latex if yo need it).
