### PR TITLE
Fix langtool-disabled-rules for v2 API

### DIFF
--- a/langtool.el
+++ b/langtool.el
@@ -1095,7 +1095,7 @@ Ordinary no need to change this."
                     ("text" ,text)
                     ,@(and langtool-mother-tongue
                            `(("motherTongue" ,langtool-mother-tongue)))
-                    ("disabled" ,disabled-rules)
+                    ("disabledRules" ,disabled-rules)
                     ))
            query-string)
       (when (and langtool-client-filter-query-function


### PR DESCRIPTION
Fix the issue with `langtool-disabled-rules` for the v2 API of LanguageTool.

To reproduce the issue, you need to set the `langtool-disabled-rules` variable to something different than `nil`:
`(setq langtool-disabled-rules '("WHITESPACE_RULE"))`
                              
Then, you open a buffer `M-x switch-to-buffer` and use `langtool-check`. This, will cause the following error:
`Error: You specified 'disabled' but the parameter is now called 'disabledRules' in v2 of the API`