### PR TITLE
Remove "^" from two regexps to improve compatibility

### DIFF
--- a/langtool.el
+++ b/langtool.el
@@ -949,7 +949,6 @@ Ordinary no need to change this."
     (cond
      ((re-search-forward (eval-when-compile
                            (concat
-                            "^"
                             "Starting LanguageTool "
                             "\\([0-9.]+\\)\\(?:-SNAPSHOT\\)? "
                             ".+?"
@@ -971,7 +970,7 @@ Ordinary no need to change this."
       (save-excursion
         (while t
           (goto-char (point-min))
-          (when (re-search-forward "^Server started" nil t)
+          (when (re-search-forward "Server started" nil t)
             (cl-destructuring-bind (version host port)
                 (langtool-server--parse-initial-buffer)
               (when (version< version "4.0")


### PR DESCRIPTION
With OpenJDK, a time stamp is printed before the server output:

     2019-12-21 15:28:53 +0000 Server started

With this change, such lines are now parsed correctly.

I have tested this with:
* emacs 26.1
* openjdk 11.0.5 2019-10-15
* LanguageTool 4.7