### PR TITLE
Add options to use LanguageTool API and premium features

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,21 @@ testing, so please open issue when the ssl/tls connection is not working.
 (setq langtool-http-server-stream-type 'tls)
 ```
 
+*Note:* you can use the free plan with the following settings:
+```
+(setq langtool-http-server-host "api.languagetoolplus.com"
+      langtool-http-server-port 443
+      langtool-http-server-stream-type 'tls)
+
+```
+
+Also, if you have a premium account, setup:
+```
+(setq langtool-http-username "<username>"
+      ;; https://languagetool.org/editor/settings/access-tokens
+      langtool-http-apiKey "<your-apiKey>")
+```
+
 ## Optional settings
 
 * Key binding if you desired.

--- a/langtool.el
+++ b/langtool.el
@@ -305,6 +305,18 @@ Valid arguments are same to above except `nil'. This means `plain'."
   :group 'langtool
   :type 'symbol)
 
+(defcustom langtool-http-server-username nil
+  "Username to access premium features"
+  :group 'langtool
+  :type 'string)
+
+(defcustom langtool-http-server-apiKey nil
+  "Access token to access premium features
+  https://languagetool.org/editor/settings/access-tokens"
+  :group 'langtool
+  :type 'string)
+
+
 (defcustom langtool-java-classpath nil
   "Custom classpath to use on special environment.  (e.g. Arch Linux)
 Do not set both of this variable and `langtool-language-tool-jar'.
@@ -1238,7 +1250,12 @@ Ordinary no need to change this."
                   ("text" ,text)
                   ,@(and langtool-mother-tongue
                          `(("motherTongue" ,langtool-mother-tongue)))
-                  ("disabledRules" ,disabled-rules)))
+                  ("disabledRules" ,disabled-rules)
+                  ,@(and langtool-http-server-username
+                         `(("username" ,langtool-http-server-username)))
+                  ,@(and langtool-http-server-apiKey
+                         `(("username" ,langtool-http-server-apiKey)))
+                  ))
          query-string)
     (when (and langtool-client-filter-query-function
                (functionp langtool-client-filter-query-function))

--- a/langtool.el
+++ b/langtool.el
@@ -349,6 +349,14 @@ String that separated by comma or list of string."
           (list string)
           string))
 
+(defcustom langtool-level nil
+  "If set to picky, additional rules will be activated"
+  :group 'langtool
+  :type '(choice
+          (const nil)
+          (const default)
+          (const picky)))
+
 (defcustom langtool-user-arguments nil
   "Similar to `langtool-java-user-arguments' except this list is appended
 after `-jar' argument.
@@ -1255,6 +1263,8 @@ Ordinary no need to change this."
                          `(("username" ,langtool-http-server-username)))
                   ,@(and langtool-http-server-apiKey
                          `(("username" ,langtool-http-server-apiKey)))
+                  ,@(and langtool-level
+                         `(("level" ,langtool-level)))
                   ))
          query-string)
     (when (and langtool-client-filter-query-function


### PR DESCRIPTION
Thanks for this great integration!

This PR provides documentation to use the [public API](https://languagetool.org/http-api/), the configurations to access the premium features, and the option to enable picky mode. 